### PR TITLE
Remove filters left progress bar if sync'd

### DIFF
--- a/Chaincase.UI/Components/Status.razor
+++ b/Chaincase.UI/Components/Status.razor
@@ -22,7 +22,7 @@
             <IonLabel>Filters left: @ViewModel.FiltersLeft</IonLabel>
         }
     </IonItem>
-    @if (ViewModel.ProgressPercent != 100)
+    @if (ViewModel.FiltersLeft != 0)
     {
         <IonItem>
             <IonProgressBar value="@ViewModel.ProgressPercent"/>


### PR DESCRIPTION
Remove progress bar once wallet is sync'd. Doesn't make sense to show a full progress bar if you're not making any more progress.

![Screen Shot 2021-10-25 at 9 11 27 PM](https://user-images.githubusercontent.com/24356537/138791997-4d18a32a-194d-416e-8949-5ca2cc0c30ba.png)
