### PR TITLE
Improve Receive flow

### DIFF
--- a/Chaincase.UI/Pages/ReceiveAddressPage.razor
+++ b/Chaincase.UI/Pages/ReceiveAddressPage.razor
@@ -5,6 +5,7 @@
 @inject NavigationManager NavigationManager
 @inject ReceiveViewModel ReceiveViewModel
 @inject IClipboard Clipboard 
+@inject StackService StackService 
 @inject IShare Share
 @inherits ReactiveComponentBase<ReceiveViewModel>
 
@@ -47,7 +48,7 @@
 
         }
     </IonList>
-    <IonButton class="neu-button" href="/overview" expand="block">DONE</IonButton>
+    <IonButton class="neu-button" OnClick="Done" expand="block">DONE</IonButton>
 </IonFooter>
 
 @code {
@@ -68,4 +69,12 @@
         await Clipboard.Copy(toCopy);
         IsToastVisible = true;
     }
+
+    private void Done()
+    {
+        StackService.ClearStack();
+        ReceiveViewModel.ReceivePubKey = null;
+        NavigationManager.NavigateTo("/overview");
+    }
+
 }

--- a/Chaincase.UI/Pages/ReceiveLabelPage.razor
+++ b/Chaincase.UI/Pages/ReceiveLabelPage.razor
@@ -5,22 +5,36 @@
 @inject UIStateService UiStateService
 @inject NavigationManager NavigationManager
 @inject ReceiveViewModel ReceiveViewModel
+@inject StackService StackService
 @inherits ReactiveComponentBase<ReceiveViewModel>
 
-<IonContent>
-    <IonItem class="ion-padding">
+
+<IonContent class="ion-padding-vertical">
+    <EditForm Model="ViewModel" OnValidSubmit="ApplyLabel">
+        <DataAnnotationsValidator/>
         <IonLabel position="stacked">Add Label</IonLabel>
-        <IonInput @bind-Value="@ViewModel.ProposedLabel" placeholder="Who are you receiving from?" />
-    </IonItem>
-    <IonCard color="primary">
-        <IonCardContent>
-            <strong>Info:</strong>
-            Contact labels help keep your activity private and organized. This information is not shared.
-        </IonCardContent>
-    </IonCard>
+        <IonItem ValidationField="() => ViewModel.ProposedLabel">
+            <IonInput @bind-Value="@ViewModel.ProposedLabel" placeholder="Who are you receiving from?"/>
+        </IonItem>
+        <div class="ion-padding">
+            <IonValidationMessage ValidationField="() => ViewModel.ProposedLabel"/>
+        </div>
+        <IonCard color="primary">
+            <IonCardContent>
+                <strong>Info:</strong>
+                Contact labels help keep your activity private and organized. This information is not shared.
+            </IonCardContent>
+        </IonCard>
+        @* This hack is so that we can have a button outside of the form triggering the submission*@
+        <input type="submit" id="btn-next" style="display: none"/>
+    </EditForm>
+
 </IonContent>
 <IonFooter class="ion-padding">
-    <IonButton class="neu-button" color="primary" @onclick="ApplyLabel" disabled="@IsContinueDisabled" expand="block">Continue</IonButton>
+    <IonButton button class="neu-button" color="primary" disabled="@IsContinueDisabled" expand="block"
+               OnClick='() => JS.InvokeVoidAsync("IonicBridge.executeFunctionByName", "btn-next", "click")'>
+        Continue
+    </IonButton>
 </IonFooter>
 
 @code {
@@ -35,7 +49,20 @@
 
     private void ApplyLabel()
     {
-        ViewModel.InitNextReceiveKey();
+        if (ViewModel.ReceivePubKey == null)
+        {
+            ViewModel.InitNextReceiveKey();
+        }
+        else if (!ViewModel.ReceivePubKey.Label.Equals(ViewModel.ProposedLabel))
+        {
+            ViewModel.UpdateKeyLabel();
+        }
+        ViewModel.ProposedLabel = "";
+        StackService.PushStackState(async () =>
+        {
+            ViewModel.ProposedLabel = ViewModel.ReceivePubKey.Label;
+            await NavigationManager.NavigateBack(null, "/receive");
+        });
         NavigationManager.NavigateTo("receive/address");
     }
 

--- a/Chaincase.UI/ViewModels/ReceiveViewModel.cs
+++ b/Chaincase.UI/ViewModels/ReceiveViewModel.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Chaincase.Common;
 using Chaincase.Common.Contracts;
 using Chaincase.Common.Services;
@@ -28,19 +29,24 @@ namespace Chaincase.UI.ViewModels
         public void InitNextReceiveKey()
         {
             ReceivePubKey = _walletManager.CurrentWallet.KeyManager.GetNextReceiveKey(ProposedLabel, out bool minGapLimitIncreased);
-            ProposedLabel = "";
             _notificationManager.RequestAuthorization();
         }
 
-        public string AppliedLabel => ReceivePubKey.Label ?? "";
-        public string Address => ReceivePubKey.GetP2wpkhAddress(_config.Network).ToString();
-        public string Pubkey => ReceivePubKey.PubKey.ToString();
-        public string KeyPath => ReceivePubKey.FullKeyPath.ToString();
+        public void UpdateKeyLabel()
+        {
+	        ReceivePubKey!.SetLabel(ProposedLabel, _walletManager.CurrentWallet.KeyManager);
+        }
 
-        public HdPubKey ReceivePubKey { get; set; }
+        public string AppliedLabel => ReceivePubKey?.Label ?? "";
+        public string Address => ReceivePubKey?.GetP2wpkhAddress(_config.Network).ToString();
+        public string Pubkey => ReceivePubKey?.PubKey.ToString();
+        public string KeyPath => ReceivePubKey?.FullKeyPath.ToString();
+
+        public HdPubKey? ReceivePubKey { get; set; }
 
         public string BitcoinUri => $"bitcoin:{Address}";
 
+        [Required(ErrorMessage = "A label is required")]
         public string ProposedLabel
         {
             get => _proposedLabel;

--- a/Chaincase.UI/wwwroot/style/global.css
+++ b/Chaincase.UI/wwwroot/style/global.css
@@ -20,7 +20,7 @@ input::-ms-reveal,
 input::-ms-clear {
     display: none;
 }
-
+/* end edge specific stuff */
 .neu-button:not(.in-toolbar) {
     font-weight: bold;
     --background: linear-gradient(180deg, var(--ion-color-step-50) -60%, var(--ion-background-color) 100%);


### PR DESCRIPTION
Makes the receive label page use the proper blazor EditForm with submission events instead of manual click handling.
Introduces stack nav between the label and addr pages as the back button was misleading on the address page.
Going back to the label page also populates the label correctly and allows you to update  it, without reserving another address