### PR TITLE
refactor send payjoin

### DIFF
--- a/Chaincase.Common/Chaincase.Common.csproj
+++ b/Chaincase.Common/Chaincase.Common.csproj
@@ -13,13 +13,23 @@
     <ItemGroup>
       <PackageReference Include="ReactiveUI" Version="13.2.2" />
       <PackageReference Include="ReactiveUI.Blazor" Version="13.2.2" />
-      <PackageReference Include="NBitcoin" Version="5.0.83" />
+      <PackageReference Include="NBitcoin" Version="7.0.1" />
+      <PackageReference Include="BIP78.Sender" Version="0.2.2" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.22" />
     </ItemGroup>
     <ItemGroup>
       <Folder Include="Models\" />
       <Folder Include="Services\Mock\" />
+      <Folder Include="PayJoin\" />
+      <Folder Include="PayJoin\Sender\" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\WalletWasabi.SDK\WalletWasabi\WalletWasabi.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+      <None Remove="BIP78.Sender" />
+      <None Remove="PayJoin\" />
+      <None Remove="PayJoin\Sender\" />
+      <None Remove="Microsoft.Extensions.Http" />
     </ItemGroup>
 </Project>

--- a/Chaincase.Common/PayJoin/PayJoinExtensions.cs
+++ b/Chaincase.Common/PayJoin/PayJoinExtensions.cs
@@ -1,0 +1,19 @@
+﻿using BTCPayServer.BIP78.Sender;
+using Chaincase.Common.PayJoin.Sender;
+using Microsoft.Extensions.DependencyInjection;
+using Chaincase.Common.Services;
+
+namespace Chaincase.Common.PayJoin
+{
+    public static class PayJoinExtensions
+    {
+        public static void AddPayJoinServices(this IServiceCollection services)
+        {
+            services.AddSingleton<IPayjoinServerCommunicator, PayjoinServerCommunicator>();
+            services.AddSingleton<PayjoinClient>();
+            services.AddTransient<Socks5HttpClientHandler>();
+            services.AddHttpClient(PayjoinServerCommunicator.PayjoinOnionNamedClient)
+                .ConfigurePrimaryHttpMessageHandler<Socks5HttpClientHandler>();
+        }
+    }
+}

--- a/Chaincase.Common/PayJoin/Sender/PayJoinServerCommunicator.cs
+++ b/Chaincase.Common/PayJoin/Sender/PayJoinServerCommunicator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Net.Http;
+using BTCPayServer.BIP78.Sender;
+
+namespace Chaincase.Common.PayJoin.Sender
+{
+    public class PayjoinServerCommunicator : HttpClientPayjoinServerCommunicator
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        public const string PayjoinOnionNamedClient = "payjoin.onion";
+        public const string PayjoinClearnetNamedClient = "payjoin.clearnet";
+
+        public PayjoinServerCommunicator(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
+        protected override HttpClient CreateHttpClient(Uri uri)
+        {
+            return _httpClientFactory.CreateClient(uri.IsOnion() ? PayjoinOnionNamedClient : PayjoinClearnetNamedClient);
+        }
+    }
+}

--- a/Chaincase.Common/PayJoin/Sender/PayjoinServerCommunicator.cs
+++ b/Chaincase.Common/PayJoin/Sender/PayjoinServerCommunicator.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Net.Http;
+using BTCPayServer.BIP78.Sender;
+
+namespace Chaincase.Common.PayJoin.Sender
+{
+    public class PayjoinServerCommunicator : HttpClientPayjoinServerCommunicator
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+        public const string PayjoinOnionNamedClient = "payjoin.onion";
+        public const string PayjoinClearnetNamedClient = "payjoin.clearnet";
+
+        public PayjoinServerCommunicator(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
+        protected override HttpClient CreateHttpClient(Uri uri)
+        {
+            return _httpClientFactory.CreateClient(uri.IsOnion() ? PayjoinOnionNamedClient : PayjoinClearnetNamedClient);
+        }
+    }
+}

--- a/Chaincase.Common/PayJoin/Sender/PayjoinWallet.cs
+++ b/Chaincase.Common/PayJoin/Sender/PayjoinWallet.cs
@@ -1,0 +1,37 @@
+﻿using System.Runtime.InteropServices.WindowsRuntime;
+using BTCPayServer.BIP78.Sender;
+using NBitcoin;
+using WalletWasabi.Blockchain.Keys;
+
+namespace Chainicase.Common.PayJoin.Sender
+{
+    public class PayjoinWallet : IPayjoinWallet
+    {
+        private readonly ExtPubKey _extPubKey;
+        private readonly RootedKeyPath _rootedKeyPath;
+
+        public PayjoinWallet(ExtPubKey extPubKey, RootedKeyPath rootedKeyPath)
+        {
+            _extPubKey = extPubKey;
+            _rootedKeyPath = rootedKeyPath;
+        }
+
+        public IHDScriptPubKey Derive(KeyPath keyPath)
+        {
+            return ((IHDScriptPubKey)_extPubKey).Derive(keyPath); 
+        }
+            
+        public bool CanDeriveHardenedPath()
+        {
+            return ((IHDScriptPubKey)_extPubKey).CanDeriveHardenedPath();
+        }
+
+        public Script ScriptPubKey => ((IHDScriptPubKey)_extPubKey).ScriptPubKey;
+
+        public ScriptPubKeyType ScriptPubKeyType => ScriptPubKeyType.Segwit;
+
+        public RootedKeyPath RootedKeyPath => _rootedKeyPath;
+
+        public IHDKey AccountKey => _extPubKey;
+    }
+}

--- a/Chaincase.Common/Services/ChaincaseWalletManager.cs
+++ b/Chaincase.Common/Services/ChaincaseWalletManager.cs
@@ -2,11 +2,20 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using BTCPayServer.BIP78.Sender;
 using Chaincase.Common.Contracts;
 using NBitcoin;
+using NBitcoin.Payment;
+using NBitcoin.Policy;
+using WalletWasabi.Blockchain.Keys;
+using WalletWasabi.Blockchain.TransactionBuilding;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Blockchain.TransactionProcessing;
 using WalletWasabi.CoinJoin.Client.Clients.Queuing;
+using WalletWasabi.Exceptions;
+using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Wallets;
 
@@ -15,14 +24,16 @@ namespace Chaincase.Common.Services
     public class ChaincaseWalletManager : WalletManager
     {
         private readonly INotificationManager _notificationManager;
+        private readonly PayjoinClient _payjoinClient;
 
         public Wallet CurrentWallet { get; set; }
         public IEnumerable<SmartCoin> SleepingCoins;
 
-        public ChaincaseWalletManager(Network network, WalletDirectories walletDirectories, INotificationManager notificationManager)
+        public ChaincaseWalletManager(Network network, WalletDirectories walletDirectories, INotificationManager notificationManager, PayjoinClient payjoinClient)
             : base(network, walletDirectories)
         {
             _notificationManager = notificationManager;
+            _payjoinClient = payjoinClient;
 
             OnDequeue += WalletManager_OnDequeue;
             WalletRelevantTransactionProcessed += WalletManager_WalletRelevantTransactionProcessed;
@@ -155,5 +166,308 @@ namespace Chaincase.Common.Services
             (string walletFullPath, _) = WalletDirectories.GetWalletFilePaths(walletName);
             return File.Exists(walletFullPath);
         }
+
+        public Task<PSBT> BuildPayjoin(
+            PaymentIntent payments,
+            IEnumerable<OutPoint> coinsToSpend,
+            string password = "",
+            bool allowUnconfirmed = false)
+        {
+            payments = Guard.NotNull(nameof(payments), payments);
+
+            // was a <param>
+            Func<LockTime> lockTimeSelector = null;
+            lockTimeSelector ??= () => LockTime.Zero;
+
+            long totalAmount = payments.TotalAmount.Satoshi;
+            if (totalAmount < 0 || totalAmount > Constants.MaximumNumberOfSatoshis)
+            {
+                throw new ArgumentOutOfRangeException($"{nameof(payments)}.{nameof(payments.TotalAmount)} sum cannot be smaller than 0 or greater than {Constants.MaximumNumberOfSatoshis}.");
+            }
+
+            // 1. Get allowed coins to spend.
+            var availableCoinsView = CurrentWallet.Coins.Available();
+            // TODO Kill SmartCoin
+            // TODO This whole logic is a dirty abstraction. Just pass enough information to spend
+            // TODO It doesn't make sense for this function to have access to that state, it should be passed in
+            List<SmartCoin> allowedSmartCoinInputs = allowUnconfirmed // Inputs that can be used to build the transaction.
+                    ? availableCoinsView.ToList()
+                    : availableCoinsView.Confirmed().ToList();
+            if (coinsToSpend != null) // If allowedInputs are specified then select the coins from them.
+            {
+                if (!coinsToSpend.Any())
+                {
+                    throw new ArgumentException($"{nameof(coinsToSpend)} is not null, but empty.");
+                }
+
+                allowedSmartCoinInputs = allowedSmartCoinInputs
+                    .Where(x => coinsToSpend.Any(y => y.Hash == x.TransactionId && y.N == x.Index))
+                    .ToList();
+
+                // Add those that have the same script, because common ownership is already exposed.
+                // But only if the user didn't click the "max" button. In this case he'd send more money than what he'd think.
+                if (payments.ChangeStrategy != ChangeStrategy.AllRemainingCustom)
+                {
+                    var allScripts = allowedSmartCoinInputs.Select(x => x.ScriptPubKey).ToHashSet();
+                    foreach (var coin in availableCoinsView.Where(x => !allowedSmartCoinInputs.Any(y => x.TransactionId == y.TransactionId && x.Index == y.Index)))
+                    {
+                        if (!(allowUnconfirmed || coin.Confirmed))
+                        {
+                            continue;
+                        }
+
+                        if (allScripts.Contains(coin.ScriptPubKey))
+                        {
+                            allowedSmartCoinInputs.Add(coin);
+                        }
+                    }
+                }
+            }
+
+            // Get and calculate fee
+            Logger.LogInfo("Calculating dynamic transaction fee...");
+
+            TransactionBuilder builder = Network.CreateTransactionBuilder();
+            builder.SetCoinSelector(new SmartCoinSelector(allowedSmartCoinInputs));
+            builder.AddCoins(allowedSmartCoinInputs.Select(c => c.GetCoin()));
+            builder.SetLockTime(lockTimeSelector());
+
+            foreach (var request in payments.Requests.Where(x => x.Amount.Type == MoneyRequestType.Value))
+            {
+                var amountRequest = request.Amount;
+
+                builder.Send(request.Destination, amountRequest.Amount);
+                if (amountRequest.SubtractFee)
+                {
+                    builder.SubtractFees();
+                }
+            }
+
+            // TODO could this be passed into the function instead of knoing about (TODO rm) KeyManager
+            HdPubKey changeHdPubKey = null;
+
+            if (payments.TryGetCustomRequest(out DestinationRequest custChange))
+            {
+                var changeScript = custChange.Destination.ScriptPubKey;
+                // TODO rm KeyManager
+                changeHdPubKey = CurrentWallet.KeyManager.GetKeyForScriptPubKey(changeScript);
+
+                var changeStrategy = payments.ChangeStrategy;
+                if (changeStrategy == ChangeStrategy.Custom)
+                {
+                    builder.SetChange(changeScript);
+                }
+                else if (changeStrategy == ChangeStrategy.AllRemainingCustom)
+                {
+                    builder.SendAllRemaining(changeScript);
+                }
+                else
+                {
+                    throw new NotSupportedException(payments.ChangeStrategy.ToString());
+                }
+            }
+            else
+            {
+                CurrentWallet.KeyManager.AssertCleanKeysIndexed(isInternal: true);
+                CurrentWallet.KeyManager.AssertLockedInternalKeysIndexed(14);
+                changeHdPubKey = CurrentWallet.KeyManager.GetKeys(KeyState.Clean, true).RandomElement();
+
+                builder.SetChange(changeHdPubKey.P2wpkhScript);
+            }
+
+            builder.OptInRBF = new Random().NextDouble() < Constants.TransactionRBFSignalRate;
+
+            FeeRate feeRate = feeRateFetcher();
+            builder.SendEstimatedFees(feeRate);
+
+            var psbt = builder.BuildPSBT(false);
+
+            var spentCoins = psbt.Inputs.Select(txin => allowedSmartCoinInputs.First(y => y.OutPoint == txin.PrevOut)).ToArray();
+
+            var realToSend = payments.Requests
+                .Select(t =>
+                    (label: t.Label,
+                    destination: t.Destination,
+                    amount: psbt.Outputs.FirstOrDefault(o => o.ScriptPubKey == t.Destination.ScriptPubKey)?.Value))
+                .Where(i => i.amount != null);
+
+            if (!psbt.TryGetFee(out var fee))
+            {
+                throw new InvalidOperationException("Impossible to get the fees of the PSBT, this should never happen.");
+            }
+            Logger.LogInfo($"Fee: {fee.Satoshi} Satoshi.");
+
+            var vSize = builder.EstimateSize(psbt.GetOriginalTransaction(), true);
+            Logger.LogInfo($"Estimated tx size: {vSize} vBytes.");
+
+            // Do some checks
+            Money totalSendAmountNoFee = realToSend.Sum(x => x.amount);
+            if (totalSendAmountNoFee == Money.Zero)
+            {
+                throw new InvalidOperationException("The amount after subtracting the fee is too small to be sent.");
+            }
+
+            Money totalOutgoingAmountNoFee;
+            if (changeHdPubKey is null)
+            {
+                totalOutgoingAmountNoFee = totalSendAmountNoFee;
+            }
+            else
+            {
+                totalOutgoingAmountNoFee = realToSend.Where(x => !changeHdPubKey.ContainsScript(x.destination.ScriptPubKey)).Sum(x => x.amount);
+            }
+            decimal totalOutgoingAmountNoFeeDecimal = totalOutgoingAmountNoFee.ToDecimal(MoneyUnit.BTC);
+            // Cannot divide by zero, so use the closest number we have to zero.
+            decimal totalOutgoingAmountNoFeeDecimalDivisor = totalOutgoingAmountNoFeeDecimal == 0 ? decimal.MinValue : totalOutgoingAmountNoFeeDecimal;
+            decimal feePc = 100 * fee.ToDecimal(MoneyUnit.BTC) / totalOutgoingAmountNoFeeDecimalDivisor;
+
+            if (feePc > 1)
+            {
+                Logger.LogInfo($"The transaction fee is {feePc:0.#}% of the sent amount.{Environment.NewLine}"
+                    + $"Sending:\t {totalOutgoingAmountNoFee.ToString(fplus: false, trimExcessZero: true)} BTC.{Environment.NewLine}"
+                    + $"Fee:\t\t {fee.Satoshi} Satoshi.");
+            }
+            if (feePc > 100)
+            {
+                throw new InvalidOperationException($"The transaction fee is more than twice the sent amount: {feePc:0.#}%.");
+            }
+
+            if (spentCoins.Any(u => !u.Confirmed))
+            {
+                Logger.LogInfo("Unconfirmed transaction is spent.");
+            }
+
+            // Build the transaction
+            Logger.LogInfo("Signing transaction...");
+            // It must be watch only, too, because if we have the key and also hardware wallet, we do not care we can sign.
+
+            Transaction tx = null;
+            if (CurrentWallet.KeyManager.IsWatchOnly)
+            {
+                tx = psbt.GetGlobalTransaction();
+            }
+            else
+            {
+                IEnumerable<ExtKey> signingKeys = CurrentWallet.KeyManager.GetSecrets(password, spentCoins.Select(x => x.ScriptPubKey).ToArray());
+                builder = builder.AddKeys(signingKeys.ToArray());
+                builder.SignPSBT(psbt);
+
+                UpdatePSBTInfo(psbt, spentCoins, changeHdPubKey);
+
+                if (!CurrentWallet.KeyManager.IsWatchOnly)
+                {
+                    // Try to pay using payjoin
+                    if (_payjoinClient is { })
+                    {
+                        psbt = TryNegotiatePayjoin(payjoinClient, builder, psbt, changeHdPubKey);
+                    }
+                }
+                psbt.Finalize();
+                tx = psbt.ExtractTransaction();
+
+                var checkResults = builder.Check(tx).ToList();
+                if (!psbt.TryGetEstimatedFeeRate(out FeeRate actualFeeRate))
+                {
+                    throw new InvalidOperationException("Impossible to get the fee rate of the PSBT, this should never happen.");
+                }
+
+                // Manually check the feerate, because some inaccuracy is possible.
+                var sb1 = feeRate.SatoshiPerByte;
+                var sb2 = actualFeeRate.SatoshiPerByte;
+                if (Math.Abs(sb1 - sb2) > 2) // 2s/b inaccuracy ok.
+                {
+                    // So it'll generate a transactionpolicy error thrown below.
+                    checkResults.Add(new NotEnoughFundsPolicyError("Fees different than expected"));
+                }
+                if (checkResults.Count > 0)
+                {
+                    throw new InvalidTxException(tx, checkResults);
+                }
+                //if (feeStrategy.Type == FeeStrategyType.Target)
+                //{
+                //    return FeeProvider.AllFeeEstimate?.GetFeeRate(feeStrategy.Target) ?? throw new InvalidOperationException("Cannot get fee estimations.");
+                //}
+                //else if (feeStrategy.Type == FeeStrategyType.Rate)
+                //{
+                //    return feeStrategy.Rate;
+                //}
+                //else
+                //{
+                //    throw new NotSupportedException(feeStrategy.Type.ToString());
+                //}
+                return Task.CompletedTask;
+            }
+        }
+
+        // <summary> Just a helper method </summary>
+        private PSBT TryNegotiatePayjoin(BitcoinUrlBuilder bip21, TransactionBuilder builder, PSBT psbt, HdPubKey changeHdPubKey)
+        {
+            try
+            {
+                bip21.TryGetPayjoinEndpoint(out var endpoint);
+                Logger.LogInfo($"Negotiating payjoin payment with `{endpoint}`.");
+
+                psbt = _payjoinClient.RequestPayjoin(bip21, new PayjoinWallet());
+                //psbt = payjoinClient.RequestPayjoin(psbt,
+                //	KeyManager.ExtPubKey,
+                //	new RootedKeyPath(KeyManager.MasterFingerprint.Value, KeyManager.DefaultAccountKeyPath),
+                //	changeHdPubKey,
+                //	CancellationToken.None).GetAwaiter().GetResult();
+                builder.SignPSBT(psbt);
+
+                Logger.LogInfo($"Payjoin payment was negotiated successfully.");
+            }
+            catch (TorSocks5FailureResponseException e)
+            {
+                if (e.Message.Contains("HostUnreachable"))
+                {
+                    Logger.LogWarning($"Payjoin server is not reachable. Ignoring...");
+                }
+                // ignore
+            }
+            catch (HttpRequestException e)
+            {
+                Logger.LogWarning($"Payjoin server responded with {e.ToTypeMessageString()}. Ignoring...");
+            }
+            catch (PayjoinException e)
+            {
+                Logger.LogWarning($"Payjoin server responded with {e.Message}. Ignoring...");
+            }
+
+            return psbt;
+        }
+
+        private void UpdatePSBTInfo(PSBT psbt, SmartCoin[] spentCoins, HdPubKey changeHdPubKey)
+        {
+            if (CurrentWallet.KeyManager.MasterFingerprint is HDFingerprint fp)
+            {
+                foreach (var coin in spentCoins)
+                {
+                    var rootKeyPath = new RootedKeyPath(fp, coin.HdPubKey.FullKeyPath);
+                    psbt.AddKeyPath(coin.HdPubKey.PubKey, rootKeyPath, coin.ScriptPubKey);
+                }
+                if (changeHdPubKey is { })
+                {
+                    var rootKeyPath = new RootedKeyPath(fp, changeHdPubKey.FullKeyPath);
+                    psbt.AddKeyPath(changeHdPubKey.PubKey, rootKeyPath, changeHdPubKey.P2wpkhScript);
+                }
+            }
+
+            foreach (var input in spentCoins)
+            {
+                var coinInputTxID = input.TransactionId;
+                if (CurrentWallet.BitcoinStore.TransactionStore.TryGetTransaction(coinInputTxID, out var txn))
+                {
+                    var psbtInputs = psbt.Inputs.Where(x => x.PrevOut.Hash == coinInputTxID);
+                    foreach (var psbtInput in psbtInputs)
+                    {
+                        psbtInput.NonWitnessUtxo = txn.Transaction;
+                    }
+                }
+                else
+                {
+                    Logger.LogWarning($"Transaction id:{coinInputTxID} is missing from the TransactionStore. Ignoring...");
+                }
+            }
+        }
     }
-}

--- a/Chaincase.Common/Services/Socks5HttpClientHandler.cs
+++ b/Chaincase.Common/Services/Socks5HttpClientHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Net;
+using System.Net.Http;
+
+namespace Chaincase.Common.Services
+{
+    public class Socks5HttpClientHandler : HttpClientHandler
+    {
+        public Socks5HttpClientHandler(Config config)
+        {
+            if (config.TorSocks5EndPoint is IPEndPoint endpoint)
+            {
+                this.Proxy = new WebProxy($"socks5://{endpoint.Address}:{endpoint.Port}");
+            }
+            else if (config.TorSocks5EndPoint is DnsEndPoint endpoint2)
+            {
+                this.Proxy = new WebProxy($"socks5://{endpoint2.Host}:{endpoint2.Port}");
+            }
+        }
+    }
+}

--- a/Chaincase.Tests/UiTests.cs
+++ b/Chaincase.Tests/UiTests.cs
@@ -8,12 +8,13 @@ using Chaincase.UI.Pages;
 using Chaincase.UI.Services;
 using Chaincase.UI.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using NBitcoin;
 using WalletWasabi.Helpers;
 using Xunit;
 
 namespace Chaincase.Tests
 {
-	public class UiTests
+    public class UiTests
     {
         private readonly TestContext ctx;
         public UiTests()
@@ -32,7 +33,7 @@ namespace Chaincase.Tests
             ctx.Services.AddScoped<ThemeSwitcher>();
 
             ctx.Services.AddSingleton<PINViewModel>();
-            ctx.Services.AddSingleton<SendViewModel>();
+            ctx.Services.AddTransient<SendViewModel>();
             ctx.Services.AddSingleton<SelectCoinsViewModel>();
             ctx.Services.AddSingleton<BackUpViewModel>();
 
@@ -54,30 +55,51 @@ namespace Chaincase.Tests
             loginPage.Find("ion-button").TextContent.MarkupMatches("LOG IN");
         }
 
-        // TODO this fails regardless of the bound disabled ViewModel value
-        // Something is wrong with the test
-        //[Fact] 
-        //public void SendButtonValidationWorks()
-        //{
-        //    var sendViewModel = ctx.Services.GetRequiredService<SendViewModel>();
 
-        //    var sendAmountPage = ctx.RenderComponent<SendAmountPage>();
-        //    var spendButton = sendAmountPage.Find("ion-button");
-        //    var disabledAttr = spendButton.Attributes.GetNamedItem("disabled");
+        [Fact]
+        public void DestinationUrlPropertyParsedFromString()
+        {
+            var sendViewModel = ctx.Services.GetRequiredService<SendViewModel>();
+            string amountString = "0.0001111";
 
-        //    Assert.True(disabledAttr.Value == "true");
-        //}
+            sendViewModel.DestinationString = $"bitcoin:BC1Q6APR55WRXTDTK3CJ6M69MXAYW99VVGTVDNVUNT?amount={amountString}&pj=https://testnet.demo.btcpayserver.org/BTC/pj";
+            var amount = Money.Parse(amountString);
+            Assert.True(sendViewModel.DestinationUrl.Amount == amount);
+            Assert.True(Money.Parse(sendViewModel.AmountText) == amount);
+            Assert.True(sendViewModel.OutputAmount == amount);
+        }
+
+        [Fact]
+        public void SendMaxAmountIsMaxSelected()
+        {
+            var sendViewModel = ctx.Services.GetRequiredService<SendViewModel>();
+            string amountString = "0.0001111";
+            var amount = Money.Parse(amountString);
+            sendViewModel.DestinationString = $"bitcoin:BC1Q6APR55WRXTDTK3CJ6M69MXAYW99VVGTVDNVUNT?amount={amountString}&pj=https://testnet.demo.btcpayserver.org/BTC/pj";
+            Assert.True(sendViewModel.DestinationUrl.Amount == amount);
+            Assert.True(Money.Parse(sendViewModel.AmountText) == amount);
+            Assert.True(sendViewModel.OutputAmount == amount);
+
+            sendViewModel.AmountText = amountString;
+            Assert.False(sendViewModel.IsMax);
+            Assert.True(sendViewModel.OutputAmount == amount);
+            sendViewModel.IsMax = true;
+
+            Assert.True(sendViewModel.DestinationUrl.Amount == amount);
+            Assert.True(Money.Parse(sendViewModel.AmountText) != amount);
+            Assert.False(sendViewModel.OutputAmount == amount);
+        }
     }
 
     public class TestDataDirProvider : SSBDataDirProvider
     {
-	    public TestDataDirProvider()
-	    {
-		    SubDirectory = Path.Combine("Test", "Client");
-	    } 
-	    public TestDataDirProvider(string dir)
-	    {
-		    SubDirectory = Path.Combine("Test", "Client", dir);
-	    } 
+        public TestDataDirProvider()
+        {
+            SubDirectory = Path.Combine("Test", "Client");
+        }
+        public TestDataDirProvider(string dir)
+        {
+            SubDirectory = Path.Combine("Test", "Client", dir);
+        }
     }
 }

--- a/Chaincase.UI/ViewModels/SendViewModel.cs
+++ b/Chaincase.UI/ViewModels/SendViewModel.cs
@@ -172,7 +172,7 @@ namespace Chaincase.UI.ViewModels
                 {
                     // since AmountText can be altered by hand, we set it instead
                     // of binding to a calculated ObservableAsPropertyHelper
-                    //AmountText = url.Amount.ToString();
+                    AmountText = url.Amount.ToString();
                 }
                 // we could check url.Label or url.Message for contact, but there is
                 // no convention on their use yet so it's hard to say whether they
@@ -421,7 +421,7 @@ namespace Chaincase.UI.ViewModels
             {
                 Logger.LogWarning("PayJoin server is an onion service but Tor is disabled. Ignoring...");
                 return null;
-            } 
+            }
 
             if (network == Network.Main && payjoinEndPointUri.Scheme != Uri.UriSchemeHttps && isTorEnabled)
             {


### PR DESCRIPTION
Takes suggestions in #255 to use the PayJoin client from [BTCPayServer.Bip78](https://github.com/btcpayserver/BTCPayServer.BIP78).Sender and stop the leaky abstraction.

separate pr so we can test & ideally release the functionality to validate the need before a complete refactor